### PR TITLE
feat: Add support for Flic Twist Action Messages and Virtual Devices

### DIFF
--- a/custom_components/flichub/__init__.py
+++ b/custom_components/flichub/__init__.py
@@ -23,7 +23,9 @@ from pyflichub.client import FlicHubTcpClient, ServerCommand
 from pyflichub.command import Command
 from pyflichub.event import Event
 from .const import CLIENT_READY_TIMEOUT, EVENT_CLICK, EVENT_DATA_NAME, EVENT_DATA_CLICK_TYPE, \
-    EVENT_DATA_SERIAL_NUMBER, DATA_BUTTONS, DATA_HUB, REQUIRED_SERVER_VERSION, DEFAULT_SCAN_INTERVAL
+    EVENT_DATA_SERIAL_NUMBER, DATA_BUTTONS, DATA_HUB, REQUIRED_SERVER_VERSION, DEFAULT_SCAN_INTERVAL, \
+    EVENT_ACTION_MESSAGE, EVENT_VIRTUAL_DEVICE_UPDATE, EVENT_DATA_ACTION, \
+    EVENT_DATA_META_DATA, EVENT_DATA_VALUES
 from .const import DOMAIN
 from .const import PLATFORMS
 
@@ -55,6 +57,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             })
         if event.event == "buttonReady":
             hass.async_create_task(coordinator.async_refresh())
+        if event.event == "actionMessage":
+            hass.bus.fire(EVENT_ACTION_MESSAGE, {
+                EVENT_DATA_ACTION: event.action
+            })
+        if event.event == "virtualDeviceUpdate":
+            hass.bus.fire(EVENT_VIRTUAL_DEVICE_UPDATE, {
+                EVENT_DATA_META_DATA: event.meta_data,
+                EVENT_DATA_VALUES: event.values
+            })
 
     def on_command(command: Command):
         _LOGGER.debug(f"Command: {command.command}, data: {command.data}")
@@ -167,6 +178,35 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     entry.add_update_listener(async_reload_entry)
+
+    async def send_virtual_device_update_state(call):
+        """Service to send virtual device update state to Flic Hub."""
+        entry_id = call.data.get("config_entry_id")
+        if entry_id is None:
+            # If not provided, try to use the first available config entry
+            if len(hass.data[DOMAIN]) > 0:
+                entry_id = list(hass.data[DOMAIN].keys())[0]
+            else:
+                _LOGGER.error("No flichub config entries found.")
+                return
+
+        if entry_id not in hass.data[DOMAIN]:
+            _LOGGER.error(f"FlicHub config entry {entry_id} not found.")
+            return
+
+        client = hass.data[DOMAIN][entry_id].client
+        dimmable_type = call.data.get("dimmable_type")
+        virtual_device_id = call.data.get("virtual_device_id")
+        values = call.data.get("values", {})
+
+        client.send_virtual_device_update_state(dimmable_type, virtual_device_id, values)
+
+    hass.services.async_register(
+        DOMAIN,
+        "send_virtual_device_update_state",
+        send_virtual_device_update_state,
+    )
+
     return True
 
 

--- a/custom_components/flichub/const.py
+++ b/custom_components/flichub/const.py
@@ -6,7 +6,7 @@ NAME = "Flic Hub"
 DOMAIN = "flichub"
 DOMAIN_DATA = f"{DOMAIN}_data"
 VERSION = "0.0.0"
-REQUIRED_SERVER_VERSION = "0.1.11"
+REQUIRED_SERVER_VERSION = "0.1.12"
 DEFAULT_SCAN_INTERVAL = 60
 
 CLIENT_READY_TIMEOUT = 20.0
@@ -22,9 +22,15 @@ BINARY_SENSOR_DEVICE_CLASS = "connectivity"
 
 # Events
 EVENT_CLICK = f"{DOMAIN}_click"
+EVENT_ACTION_MESSAGE = f"{DOMAIN}_action_message"
+EVENT_VIRTUAL_DEVICE_UPDATE = f"{DOMAIN}_virtual_device_update"
+
 EVENT_DATA_CLICK_TYPE = "click_type"
 EVENT_DATA_NAME = "name"
 EVENT_DATA_SERIAL_NUMBER = "serial_number"
+EVENT_DATA_ACTION = "action"
+EVENT_DATA_META_DATA = "meta_data"
+EVENT_DATA_VALUES = "values"
 
 # Platforms
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]

--- a/custom_components/flichub/manifest.json
+++ b/custom_components/flichub/manifest.json
@@ -17,6 +17,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/JohNan/home-assistant-flichub/issues",
   "loggers": ["pyflichub"],
-  "requirements": ["pyflichub-tcpclient==0.1.11"],
+  "requirements": ["pyflichub-tcpclient==0.1.12"],
   "version": "v0.0.0"
 }

--- a/custom_components/flichub/services.yaml
+++ b/custom_components/flichub/services.yaml
@@ -1,0 +1,33 @@
+send_virtual_device_update_state:
+  name: Send Virtual Device Update State
+  description: Send a state update to a Flic Twist virtual device.
+  fields:
+    config_entry_id:
+      name: Config Entry ID
+      description: The ID of the Flic Hub config entry. If not provided, the first available hub will be used.
+      example: "71f76016e300fc773f32420bb5982ab7"
+      required: false
+      selector:
+        config_entry:
+          integration: flichub
+    dimmable_type:
+      name: Dimmable Type
+      description: The type of dimmable device (e.g., 'light').
+      example: "light"
+      required: true
+      selector:
+        text:
+    virtual_device_id:
+      name: Virtual Device ID
+      description: The ID of the virtual device to update.
+      example: "my_light_1"
+      required: true
+      selector:
+        text:
+    values:
+      name: Values
+      description: The values to send to the virtual device.
+      example: '{"brightness": 100, "on": true}'
+      required: true
+      selector:
+        object:


### PR DESCRIPTION
Add support for Flic Twist Action Messages and Virtual Devices.

- Bumps pyflichub-tcpclient to version 0.1.12 to ingest the new functionality.
- Adds appropriate handlers to fire new Home Assistant bus events when actions and virtual device updates are received from the hub.
- Registers a new custom service `flichub.send_virtual_device_update_state` (along with a `services.yaml` definition) allowing users to easily send state updates back to their Flic Hub to synchronize Flic Twist smart dials.

---
*PR created automatically by Jules for task [7469569180402041471](https://jules.google.com/task/7469569180402041471) started by @JohNan*