### PR TITLE
Fix SchemaError in OptionsFlow for FlicHub

### DIFF
--- a/custom_components/flichub/config_flow.py
+++ b/custom_components/flichub/config_flow.py
@@ -176,7 +176,7 @@ class FlicHubOptionsFlowHandler(config_entries.OptionsFlow):
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required(x, default=self.options.get(x, True)): bool
+                    vol.Required(x.value, default=self.options.get(x.value, True)): bool
                     for x in sorted(PLATFORMS)
                 }
             ),


### PR DESCRIPTION
Fixes `voluptuous.error.SchemaError: unsupported schema data type 'EntityPlatforms'` when setting up or modifying options in the FlicHub config flow. This error occurs because Home Assistant upgraded `Platform` constants to Enums, and Voluptuous requires string keys for schema definitions. Fixed by using `x.value` instead of `x` when defining the schema for platforms.

---
*PR created automatically by Jules for task [14349467766725712732](https://jules.google.com/task/14349467766725712732) started by @JohNan*