### PR TITLE
Add device triggers and support double_hold

### DIFF
--- a/custom_components/flichub/binary_sensor.py
+++ b/custom_components/flichub/binary_sensor.py
@@ -199,7 +199,7 @@ class FlicHubButtonBinarySensor(FlicHubButtonEntity, BinarySensorEntity):
         name = event.data[EVENT_DATA_NAME]
         click_type: Event = event.data[EVENT_DATA_CLICK_TYPE]
         _LOGGER.debug(f"Button {name} clicked: {click_type}")
-        if click_type in ['single', 'double', 'hold', 'idle']:
+        if click_type in ['single', 'double', 'hold', 'double_hold', 'idle']:
             self._click_type = click_type
 
         if click_type == 'down':

--- a/custom_components/flichub/device_trigger.py
+++ b/custom_components/flichub/device_trigger.py
@@ -1,0 +1,96 @@
+"""Provides device triggers for Flic Hub."""
+import voluptuous as vol
+
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_PLATFORM,
+    CONF_TYPE,
+)
+from homeassistant.core import HomeAssistant, CALLBACK_TYPE
+from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
+from homeassistant.components.homeassistant.triggers import event as event_trigger
+
+from .const import DOMAIN, EVENT_CLICK, EVENT_DATA_CLICK_TYPE, EVENT_DATA_SERIAL_NUMBER
+
+# The trigger types that a button can emit
+TRIGGER_TYPES = {"single", "double", "hold", "down", "up", "double_hold"}
+
+TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
+    }
+)
+
+
+async def async_get_triggers(
+    hass: HomeAssistant, device_id: str
+) -> list[dict]:
+    """List device triggers for Flic Hub button devices."""
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get(device_id)
+
+    # Make sure device is managed by this domain
+    if device is None or DOMAIN not in [identifier[0] for identifier in device.identifiers]:
+        return []
+
+    # We shouldn't add button triggers for the Hub itself.
+    is_hub = device.model == "LR" or device.name == "Flic Hub"
+    if is_hub:
+        return []
+
+    return [
+        {
+            CONF_PLATFORM: "device",
+            CONF_DOMAIN: DOMAIN,
+            CONF_DEVICE_ID: device_id,
+            CONF_TYPE: trigger_type,
+        }
+        for trigger_type in TRIGGER_TYPES
+    ]
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: dict,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
+) -> CALLBACK_TYPE:
+    """Attach a trigger."""
+    config = TRIGGER_SCHEMA(config)
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get(config[CONF_DEVICE_ID])
+
+    if device is None:
+        raise ValueError(f"Device {config[CONF_DEVICE_ID]} not found")
+
+    # Find the serial number from identifiers
+    serial_number = next(
+        (
+            identifier[1]
+            for identifier in device.identifiers
+            if identifier[0] == DOMAIN
+        ),
+        None,
+    )
+
+    if not serial_number:
+        raise ValueError(f"Device {config[CONF_DEVICE_ID]} is missing serial number")
+
+    trigger_type = config[CONF_TYPE]
+
+    # Listen for the corresponding EVENT_CLICK
+    event_config = event_trigger.TRIGGER_SCHEMA({
+        event_trigger.CONF_PLATFORM: "event",
+        event_trigger.CONF_EVENT_TYPE: EVENT_CLICK,
+        event_trigger.CONF_EVENT_DATA: {
+            EVENT_DATA_SERIAL_NUMBER: serial_number,
+            EVENT_DATA_CLICK_TYPE: trigger_type,
+        },
+    })
+
+    return await event_trigger.async_attach_trigger(
+        hass, event_config, action, trigger_info, platform_type="device"
+    )

--- a/custom_components/flichub/strings.json
+++ b/custom_components/flichub/strings.json
@@ -34,5 +34,15 @@
       "title": "Invalid server version on FlicHub",
       "description": "The TCP server on the FlicHub is running version `{flichub_version}` which does not match the required version `{required_version}`. Please update the TCP server on the FlicHub."
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "single": "Single click",
+      "double": "Double click",
+      "hold": "Hold",
+      "down": "Button down",
+      "up": "Button up",
+      "double_hold": "Double click and hold"
+    }
   }
 }


### PR DESCRIPTION
Added Home Assistant device triggers for Flic buttons and supported `double_hold`.

---
*PR created automatically by Jules for task [3804366337264807654](https://jules.google.com/task/3804366337264807654) started by @JohNan*