### PR TITLE
Add support for buttonNumber

### DIFF
--- a/custom_components/flichub/__init__.py
+++ b/custom_components/flichub/__init__.py
@@ -25,7 +25,7 @@ from pyflichub.event import Event
 from .const import CLIENT_READY_TIMEOUT, EVENT_CLICK, EVENT_DATA_NAME, EVENT_DATA_CLICK_TYPE, \
     EVENT_DATA_SERIAL_NUMBER, DATA_BUTTONS, DATA_HUB, REQUIRED_SERVER_VERSION, DEFAULT_SCAN_INTERVAL, \
     EVENT_ACTION_MESSAGE, EVENT_VIRTUAL_DEVICE_UPDATE, EVENT_DATA_ACTION, \
-    EVENT_DATA_META_DATA, EVENT_DATA_VALUES
+    EVENT_DATA_META_DATA, EVENT_DATA_VALUES, EVENT_DATA_BUTTON_NUMBER
 from .const import DOMAIN
 from .const import PLATFORMS
 
@@ -60,7 +60,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             hass.bus.fire(EVENT_CLICK, {
                 EVENT_DATA_SERIAL_NUMBER: button.serial_number,
                 EVENT_DATA_NAME: button.name,
-                EVENT_DATA_CLICK_TYPE: event.action
+                EVENT_DATA_CLICK_TYPE: event.action,
+                EVENT_DATA_BUTTON_NUMBER: event.button_number
             })
         if event.event == "buttonDeleted":
             device_registry = dr.async_get(hass)

--- a/custom_components/flichub/binary_sensor.py
+++ b/custom_components/flichub/binary_sensor.py
@@ -13,7 +13,7 @@ from pyflichub.flichub import FlicHubInfo
 from . import FlicHubEntryData
 from .const import DOMAIN
 from .const import EVENT_CLICK, EVENT_DATA_CLICK_TYPE, \
-    EVENT_DATA_SERIAL_NUMBER, EVENT_DATA_NAME, DATA_BUTTONS, DATA_HUB
+    EVENT_DATA_SERIAL_NUMBER, EVENT_DATA_NAME, DATA_BUTTONS, DATA_HUB, EVENT_DATA_BUTTON_NUMBER
 from .entity import FlicHubButtonEntity, FlicHubEntity
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -192,6 +192,7 @@ class FlicHubButtonBinarySensor(FlicHubButtonEntity, BinarySensorEntity):
         self._attr_unique_id = f"{self.serial_number}-button"
         self._is_on = False
         self._click_type = None
+        self._button_number = None
         hass.bus.async_listen(EVENT_CLICK, self._event_callback)
 
     @property
@@ -202,7 +203,10 @@ class FlicHubButtonBinarySensor(FlicHubButtonEntity, BinarySensorEntity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes."""
-        attrs = {"click_type": self._click_type}
+        attrs = {
+            "click_type": self._click_type,
+            "button_number": self._button_number
+        }
         attrs.update(super().extra_state_attributes)
         return attrs
 
@@ -214,9 +218,15 @@ class FlicHubButtonBinarySensor(FlicHubButtonEntity, BinarySensorEntity):
 
         name = event.data[EVENT_DATA_NAME]
         click_type: Event = event.data[EVENT_DATA_CLICK_TYPE]
-        _LOGGER.debug(f"Button {name} clicked: {click_type}")
+        button_number = event.data.get(EVENT_DATA_BUTTON_NUMBER)
+
+        _LOGGER.debug(f"Button {name} clicked: {click_type}, button_number: {button_number}")
+
         if click_type in ['single', 'double', 'hold', 'double_hold', 'idle']:
             self._click_type = click_type
+
+        if button_number is not None:
+            self._button_number = button_number
 
         if click_type == 'down':
             self._is_on = True

--- a/custom_components/flichub/const.py
+++ b/custom_components/flichub/const.py
@@ -31,6 +31,7 @@ EVENT_DATA_SERIAL_NUMBER = "serial_number"
 EVENT_DATA_ACTION = "action"
 EVENT_DATA_META_DATA = "meta_data"
 EVENT_DATA_VALUES = "values"
+EVENT_DATA_BUTTON_NUMBER = "button_number"
 
 # Platforms
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]

--- a/custom_components/flichub/manifest.json
+++ b/custom_components/flichub/manifest.json
@@ -17,6 +17,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/JohNan/home-assistant-flichub/issues",
   "loggers": ["pyflichub"],
-  "requirements": ["pyflichub-tcpclient==0.1.14"],
+  "requirements": ["pyflichub-tcpclient==0.1.15"],
   "version": "v0.0.0"
 }


### PR DESCRIPTION
Updates the requirement for pyflichub-tcpclient to 0.1.15 and plumbs the new button_number property from events down to entity attributes on Home Assistant binary sensors.

---
*PR created automatically by Jules for task [17019559009502683447](https://jules.google.com/task/17019559009502683447) started by @JohNan*