### PR TITLE
Add support for Flic Twist Virtual Devices

### DIFF
--- a/custom_components/flichub/__init__.py
+++ b/custom_components/flichub/__init__.py
@@ -25,7 +25,7 @@ from pyflichub.event import Event
 from .const import CLIENT_READY_TIMEOUT, EVENT_CLICK, EVENT_DATA_NAME, EVENT_DATA_CLICK_TYPE, \
     EVENT_DATA_SERIAL_NUMBER, DATA_BUTTONS, DATA_HUB, REQUIRED_SERVER_VERSION, DEFAULT_SCAN_INTERVAL, \
     EVENT_ACTION_MESSAGE, EVENT_VIRTUAL_DEVICE_UPDATE, EVENT_DATA_ACTION, \
-    EVENT_DATA_META_DATA, EVENT_DATA_VALUES, EVENT_DATA_BUTTON_NUMBER
+    EVENT_DATA_META_DATA, EVENT_DATA_VALUES, EVENT_DATA_BUTTON_NUMBER, DATA_VIRTUAL_DEVICES
 from .const import DOMAIN
 from .const import PLATFORMS
 
@@ -82,6 +82,35 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 EVENT_DATA_ACTION: event.action
             })
         if event.event == "virtualDeviceUpdate":
+            button_id = event.meta_data.get("button_id")
+            virtual_device_id = event.meta_data.get("virtual_device_id")
+            dimmable_type = event.meta_data.get("dimmable_type")
+
+            # Persist and dispatch creation if not already created
+            if button_id and virtual_device_id and dimmable_type:
+                # Add it to the config entry options (or data)
+                new_device = {
+                    "button_id": button_id,
+                    "virtual_device_id": virtual_device_id,
+                    "dimmable_type": dimmable_type,
+                }
+
+                virtual_devices = entry.data.get(DATA_VIRTUAL_DEVICES, [])
+
+                # Check if it already exists
+                exists = any(d.get("button_id") == button_id and d.get("virtual_device_id") == virtual_device_id for d in virtual_devices)
+
+                if not exists:
+                    # Update config entry
+                    new_virtual_devices = virtual_devices + [new_device]
+                    new_data = dict(entry.data)
+                    new_data[DATA_VIRTUAL_DEVICES] = new_virtual_devices
+                    hass.config_entries.async_update_entry(entry, data=new_data)
+
+                    # Dispatch to platform setup
+                    from homeassistant.helpers.dispatcher import async_dispatcher_send
+                    async_dispatcher_send(hass, f"{DOMAIN}_{entry.entry_id}_add_virtual_device", new_device)
+
             hass.bus.fire(EVENT_VIRTUAL_DEVICE_UPDATE, {
                 EVENT_DATA_META_DATA: event.meta_data,
                 EVENT_DATA_VALUES: event.values

--- a/custom_components/flichub/const.py
+++ b/custom_components/flichub/const.py
@@ -16,6 +16,7 @@ ICON = "mdi:format-quote-close"
 
 DATA_BUTTONS = "buttons"
 DATA_HUB = "network"
+DATA_VIRTUAL_DEVICES = "virtual_devices"
 
 # Device classes
 BINARY_SENSOR_DEVICE_CLASS = "connectivity"
@@ -34,7 +35,7 @@ EVENT_DATA_VALUES = "values"
 EVENT_DATA_BUTTON_NUMBER = "button_number"
 
 # Platforms
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.LIGHT, Platform.MEDIA_PLAYER, Platform.COVER]
 
 # Defaults
 DEFAULT_NAME = DOMAIN

--- a/custom_components/flichub/cover.py
+++ b/custom_components/flichub/cover.py
@@ -1,0 +1,130 @@
+"""Cover platform for Flic Hub Virtual Devices."""
+import logging
+from typing import Any
+
+from homeassistant.components.cover import CoverEntity, CoverDeviceClass, CoverEntityFeature
+from homeassistant.core import HomeAssistant, Event
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from pyflichub.flichub import FlicHubInfo
+
+from . import FlicHubEntryData
+from .const import DOMAIN, DATA_BUTTONS, DATA_HUB, DATA_VIRTUAL_DEVICES
+from .const import EVENT_VIRTUAL_DEVICE_UPDATE, EVENT_DATA_META_DATA, EVENT_DATA_VALUES
+from .entity import FlicHubButtonEntity
+
+_LOGGER: logging.Logger = logging.getLogger(__package__)
+
+async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
+    """Set up the cover platform."""
+    data_entry: FlicHubEntryData = hass.data[DOMAIN][entry.entry_id]
+    flic_hub = data_entry.coordinator.data[DATA_HUB]
+
+    # Add existing virtual devices
+    virtual_devices = entry.data.get(DATA_VIRTUAL_DEVICES, [])
+    devices = []
+    for device_info in virtual_devices:
+        if device_info.get("dimmable_type") == "Blind":
+            button_id = device_info.get("button_id")
+            virtual_device_id = device_info.get("virtual_device_id")
+            if button_id in data_entry.coordinator.data[DATA_BUTTONS]:
+                devices.append(
+                    FlicHubVirtualBlind(
+                        hass,
+                        data_entry.coordinator,
+                        entry,
+                        button_id,
+                        virtual_device_id,
+                        flic_hub
+                    )
+                )
+
+    if devices:
+        async_add_devices(devices)
+
+    def async_add_virtual_device(device_info):
+        """Add virtual device dynamically."""
+        if device_info.get("dimmable_type") == "Blind":
+            button_id = device_info.get("button_id")
+            virtual_device_id = device_info.get("virtual_device_id")
+            if button_id in data_entry.coordinator.data[DATA_BUTTONS]:
+                async_add_devices([
+                    FlicHubVirtualBlind(
+                        hass,
+                        data_entry.coordinator,
+                        entry,
+                        button_id,
+                        virtual_device_id,
+                        flic_hub
+                    )
+                ])
+
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, f"{DOMAIN}_{entry.entry_id}_add_virtual_device", async_add_virtual_device)
+    )
+
+
+class FlicHubVirtualBlind(FlicHubButtonEntity, CoverEntity):
+    """Flic Hub Virtual Blind class."""
+
+    _attr_has_entity_name = True
+    _attr_device_class = CoverDeviceClass.BLIND
+    _attr_supported_features = CoverEntityFeature.SET_POSITION
+
+    def __init__(self, hass: HomeAssistant, coordinator, config_entry, serial_number: str, virtual_device_id: str, flic_hub: FlicHubInfo):
+        """Initialize the virtual cover."""
+        super().__init__(coordinator, config_entry, serial_number, flic_hub)
+        self._virtual_device_id = virtual_device_id
+
+        # Entity attributes
+        self._attr_unique_id = f"{self.serial_number}-{virtual_device_id}"
+        self._attr_name = virtual_device_id
+
+        # State
+        self._position = 100 # Default open
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.hass.bus.async_listen(EVENT_VIRTUAL_DEVICE_UPDATE, self._event_callback)
+        )
+
+    def _event_callback(self, event: Event):
+        """Handle virtual device update event."""
+        meta_data = event.data.get(EVENT_DATA_META_DATA, {})
+        button_id = meta_data.get("button_id")
+        virtual_device_id = meta_data.get("virtual_device_id")
+
+        if button_id != self.serial_number or virtual_device_id != self._virtual_device_id:
+            return
+
+        values = event.data.get(EVENT_DATA_VALUES, {})
+
+        # The values themselves are always floating point numbers between 0 and 1
+        # Extract and convert values
+        if "position" in values:
+            self._position = int(values["position"] * 100)
+
+        self.schedule_update_ha_state()
+
+    @property
+    def current_cover_position(self) -> int | None:
+        """Return current position of cover. None is unknown, 0 is closed, 100 is fully open."""
+        return self._position
+
+    @property
+    def is_closed(self) -> bool | None:
+        """Return if the cover is closed or not."""
+        if self._position is None:
+            return None
+        return self._position == 0
+
+    async def async_set_cover_position(self, **kwargs: Any) -> None:
+        """Move the cover to a specific position."""
+        position = kwargs.get("position", 100)
+        client = self.coordinator.hass.data[DOMAIN][self.config_entry.entry_id].client
+        values = {"position": position / 100.0}
+        self._position = position
+        client.send_virtual_device_update_state("Blind", self._virtual_device_id, values)
+        self.async_write_ha_state()

--- a/custom_components/flichub/light.py
+++ b/custom_components/flichub/light.py
@@ -1,0 +1,179 @@
+"""Light platform for Flic Hub Virtual Devices."""
+import logging
+from typing import Any
+
+from homeassistant.components.light import ColorMode, LightEntity
+from homeassistant.core import HomeAssistant, Event
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from pyflichub.flichub import FlicHubInfo
+
+from . import FlicHubEntryData
+from .const import DOMAIN, DATA_BUTTONS, DATA_HUB, DATA_VIRTUAL_DEVICES
+from .const import EVENT_VIRTUAL_DEVICE_UPDATE, EVENT_DATA_META_DATA, EVENT_DATA_VALUES
+from .entity import FlicHubButtonEntity
+
+_LOGGER: logging.Logger = logging.getLogger(__package__)
+
+async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
+    """Set up the light platform."""
+    data_entry: FlicHubEntryData = hass.data[DOMAIN][entry.entry_id]
+    flic_hub = data_entry.coordinator.data[DATA_HUB]
+
+    # Add existing virtual devices
+    virtual_devices = entry.data.get(DATA_VIRTUAL_DEVICES, [])
+    devices = []
+    for device_info in virtual_devices:
+        if device_info.get("dimmable_type") == "Light":
+            button_id = device_info.get("button_id")
+            virtual_device_id = device_info.get("virtual_device_id")
+            if button_id in data_entry.coordinator.data[DATA_BUTTONS]:
+                devices.append(
+                    FlicHubVirtualLight(
+                        hass,
+                        data_entry.coordinator,
+                        entry,
+                        button_id,
+                        virtual_device_id,
+                        flic_hub
+                    )
+                )
+
+    if devices:
+        async_add_devices(devices)
+
+    def async_add_virtual_device(device_info):
+        """Add virtual device dynamically."""
+        if device_info.get("dimmable_type") == "Light":
+            button_id = device_info.get("button_id")
+            virtual_device_id = device_info.get("virtual_device_id")
+            if button_id in data_entry.coordinator.data[DATA_BUTTONS]:
+                async_add_devices([
+                    FlicHubVirtualLight(
+                        hass,
+                        data_entry.coordinator,
+                        entry,
+                        button_id,
+                        virtual_device_id,
+                        flic_hub
+                    )
+                ])
+
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, f"{DOMAIN}_{entry.entry_id}_add_virtual_device", async_add_virtual_device)
+    )
+
+
+class FlicHubVirtualLight(FlicHubButtonEntity, LightEntity):
+    """Flic Hub Virtual Light class."""
+
+    _attr_has_entity_name = True
+    _attr_color_mode = ColorMode.HS
+    _attr_supported_color_modes = {ColorMode.HS, ColorMode.COLOR_TEMP}
+
+    def __init__(self, hass: HomeAssistant, coordinator, config_entry, serial_number: str, virtual_device_id: str, flic_hub: FlicHubInfo):
+        """Initialize the virtual light."""
+        super().__init__(coordinator, config_entry, serial_number, flic_hub)
+        self._virtual_device_id = virtual_device_id
+
+        # Entity attributes
+        self._attr_unique_id = f"{self.serial_number}-{virtual_device_id}"
+        self._attr_name = virtual_device_id
+
+        # State
+        self._is_on = False
+        self._brightness = 255
+        self._hs_color = None
+        self._color_temp = None
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.hass.bus.async_listen(EVENT_VIRTUAL_DEVICE_UPDATE, self._event_callback)
+        )
+
+    def _event_callback(self, event: Event):
+        """Handle virtual device update event."""
+        meta_data = event.data.get(EVENT_DATA_META_DATA, {})
+        button_id = meta_data.get("button_id")
+        virtual_device_id = meta_data.get("virtual_device_id")
+
+        if button_id != self.serial_number or virtual_device_id != self._virtual_device_id:
+            return
+
+        values = event.data.get(EVENT_DATA_VALUES, {})
+
+        # The values themselves are always floating point numbers between 0 and 1
+        # Extract and convert values
+        if "brightness" in values:
+            self._brightness = int(values["brightness"] * 255)
+            self._is_on = self._brightness > 0
+
+        if "hue" in values and "saturation" in values:
+            self._hs_color = (values["hue"] * 360, values["saturation"] * 100)
+            self._attr_color_mode = ColorMode.HS
+
+        if "colorTemperature" in values:
+            # We don't have min/max mireds strictly defined by flic, keep it simple or convert if needed
+            self._color_temp = int(values["colorTemperature"] * 500)  # rough estimation
+            self._attr_color_mode = ColorMode.COLOR_TEMP
+
+        if "is_on" in values:
+            self._is_on = bool(values["is_on"])
+
+        self.schedule_update_ha_state()
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if entity is on."""
+        return self._is_on
+
+    @property
+    def brightness(self) -> int | None:
+        """Return the brightness of this light between 0..255."""
+        return self._brightness
+
+    @property
+    def hs_color(self) -> tuple[float, float] | None:
+        """Return the hue and saturation color value [float, float]."""
+        return self._hs_color
+
+    @property
+    def color_temp(self) -> int | None:
+        """Return the CT color value in mireds."""
+        return self._color_temp
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        client = self.coordinator.hass.data[DOMAIN][self.config_entry.entry_id].client
+
+        values = {}
+        if "brightness" in kwargs:
+            values["brightness"] = kwargs["brightness"] / 255.0
+            self._brightness = kwargs["brightness"]
+        else:
+            values["brightness"] = self._brightness / 255.0 if self._brightness else 1.0
+            self._brightness = self._brightness if self._brightness else 255
+
+        if "hs_color" in kwargs:
+            values["hue"] = kwargs["hs_color"][0] / 360.0
+            values["saturation"] = kwargs["hs_color"][1] / 100.0
+            self._hs_color = kwargs["hs_color"]
+
+        if "color_temp" in kwargs:
+            values["colorTemperature"] = kwargs["color_temp"] / 500.0
+            self._color_temp = kwargs["color_temp"]
+
+        self._is_on = True
+
+        client.send_virtual_device_update_state("Light", self._virtual_device_id, values)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        client = self.coordinator.hass.data[DOMAIN][self.config_entry.entry_id].client
+        values = {"brightness": 0.0}
+        self._is_on = False
+        client.send_virtual_device_update_state("Light", self._virtual_device_id, values)
+        self.async_write_ha_state()

--- a/custom_components/flichub/media_player.py
+++ b/custom_components/flichub/media_player.py
@@ -1,0 +1,128 @@
+"""Media Player platform for Flic Hub Virtual Devices."""
+import logging
+from typing import Any
+
+from homeassistant.components.media_player import MediaPlayerEntity, MediaPlayerDeviceClass, MediaPlayerEntityFeature, MediaPlayerState
+from homeassistant.core import HomeAssistant, Event
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from pyflichub.flichub import FlicHubInfo
+
+from . import FlicHubEntryData
+from .const import DOMAIN, DATA_BUTTONS, DATA_HUB, DATA_VIRTUAL_DEVICES
+from .const import EVENT_VIRTUAL_DEVICE_UPDATE, EVENT_DATA_META_DATA, EVENT_DATA_VALUES
+from .entity import FlicHubButtonEntity
+
+_LOGGER: logging.Logger = logging.getLogger(__package__)
+
+async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
+    """Set up the media player platform."""
+    data_entry: FlicHubEntryData = hass.data[DOMAIN][entry.entry_id]
+    flic_hub = data_entry.coordinator.data[DATA_HUB]
+
+    # Add existing virtual devices
+    virtual_devices = entry.data.get(DATA_VIRTUAL_DEVICES, [])
+    devices = []
+    for device_info in virtual_devices:
+        if device_info.get("dimmable_type") == "Speaker":
+            button_id = device_info.get("button_id")
+            virtual_device_id = device_info.get("virtual_device_id")
+            if button_id in data_entry.coordinator.data[DATA_BUTTONS]:
+                devices.append(
+                    FlicHubVirtualSpeaker(
+                        hass,
+                        data_entry.coordinator,
+                        entry,
+                        button_id,
+                        virtual_device_id,
+                        flic_hub
+                    )
+                )
+
+    if devices:
+        async_add_devices(devices)
+
+    def async_add_virtual_device(device_info):
+        """Add virtual device dynamically."""
+        if device_info.get("dimmable_type") == "Speaker":
+            button_id = device_info.get("button_id")
+            virtual_device_id = device_info.get("virtual_device_id")
+            if button_id in data_entry.coordinator.data[DATA_BUTTONS]:
+                async_add_devices([
+                    FlicHubVirtualSpeaker(
+                        hass,
+                        data_entry.coordinator,
+                        entry,
+                        button_id,
+                        virtual_device_id,
+                        flic_hub
+                    )
+                ])
+
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, f"{DOMAIN}_{entry.entry_id}_add_virtual_device", async_add_virtual_device)
+    )
+
+
+class FlicHubVirtualSpeaker(FlicHubButtonEntity, MediaPlayerEntity):
+    """Flic Hub Virtual Speaker class."""
+
+    _attr_has_entity_name = True
+    _attr_device_class = MediaPlayerDeviceClass.SPEAKER
+    _attr_supported_features = MediaPlayerEntityFeature.VOLUME_SET
+
+    def __init__(self, hass: HomeAssistant, coordinator, config_entry, serial_number: str, virtual_device_id: str, flic_hub: FlicHubInfo):
+        """Initialize the virtual speaker."""
+        super().__init__(coordinator, config_entry, serial_number, flic_hub)
+        self._virtual_device_id = virtual_device_id
+
+        # Entity attributes
+        self._attr_unique_id = f"{self.serial_number}-{virtual_device_id}"
+        self._attr_name = virtual_device_id
+
+        # State
+        self._volume_level = 0.5
+        self._state = MediaPlayerState.PLAYING
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.hass.bus.async_listen(EVENT_VIRTUAL_DEVICE_UPDATE, self._event_callback)
+        )
+
+    def _event_callback(self, event: Event):
+        """Handle virtual device update event."""
+        meta_data = event.data.get(EVENT_DATA_META_DATA, {})
+        button_id = meta_data.get("button_id")
+        virtual_device_id = meta_data.get("virtual_device_id")
+
+        if button_id != self.serial_number or virtual_device_id != self._virtual_device_id:
+            return
+
+        values = event.data.get(EVENT_DATA_VALUES, {})
+
+        # The values themselves are always floating point numbers between 0 and 1
+        # Extract and convert values
+        if "volume" in values:
+            self._volume_level = float(values["volume"])
+
+        self.schedule_update_ha_state()
+
+    @property
+    def state(self) -> MediaPlayerState | None:
+        """State of the player."""
+        return self._state
+
+    @property
+    def volume_level(self) -> float | None:
+        """Volume level of the media player (0..1)."""
+        return self._volume_level
+
+    async def async_set_volume_level(self, volume: float) -> None:
+        """Set volume level, range 0..1."""
+        client = self.coordinator.hass.data[DOMAIN][self.config_entry.entry_id].client
+        values = {"volume": volume}
+        self._volume_level = volume
+        client.send_virtual_device_update_state("Speaker", self._virtual_device_id, values)
+        self.async_write_ha_state()


### PR DESCRIPTION
Add support for Flic Twist Virtual Devices

This pull request introduces dynamic virtual device creation for Flic Twist devices configured via the Flic Hub SDK. 

### Features
- Virtual devices with `dimmable_type` set to `'Light'`, `'Speaker'`, or `'Blind'` are automatically discovered when a `virtualDeviceUpdate` event is received.
- Correlating Home Assistant entities are dynamically spun up in new platform domains (`light`, `media_player`, `cover`).
- Entity states update smoothly in real-time as events stream in from the Hub.
- Control actions taken in Home Assistant (e.g., turning on a light, setting volume, or opening a cover) dispatch state updates cleanly back to the Flic Hub using `client.send_virtual_device_update_state(...)`.
- The discovery status for virtual devices is persisted directly to the configuration entry to guarantee devices restore correctly upon Home Assistant reboot.

---
*PR created automatically by Jules for task [5019874767771646421](https://jules.google.com/task/5019874767771646421) started by @JohNan*