### PR TITLE
Fix device automation trigger translations in UI

### DIFF
--- a/custom_components/flichub/translations/en.json
+++ b/custom_components/flichub/translations/en.json
@@ -34,5 +34,15 @@
       "title": "Invalid server version on FlicHub",
       "description": "The TCP server on the FlicHub is running version `{flichub_version}` which does not match the required version `{required_version}`. Please update the TCP server on the FlicHub."
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "single": "Single click",
+      "double": "Double click",
+      "hold": "Hold",
+      "down": "Button down",
+      "up": "Button up",
+      "double_hold": "Double click and hold"
+    }
   }
 }


### PR DESCRIPTION
This adds the missing `device_automation` block with its `trigger_type`s to `translations/en.json`, mirroring the existing block in `strings.json`. This ensures that Home Assistant will correctly show the English fallback strings ("Single click", etc.) for users in locales where translated strings are unavailable, rather than an empty or default string.

---
*PR created automatically by Jules for task [5457243423998152042](https://jules.google.com/task/5457243423998152042) started by @JohNan*