### PR TITLE
Fix virtual device creation by resolving MAC address in payload to serial number

### DIFF
--- a/custom_components/flichub/const.py
+++ b/custom_components/flichub/const.py
@@ -39,3 +39,12 @@ PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.LIGHT, Platform.M
 
 # Defaults
 DEFAULT_NAME = DOMAIN
+
+def get_button_by_id(buttons, button_id: str):
+    """Helper function to find a button by serial_number or bdaddr."""
+    if button_id in buttons:
+        return buttons[button_id]
+    for button in buttons.values():
+        if button.bdaddr == button_id:
+            return button
+    return None

--- a/custom_components/flichub/cover.py
+++ b/custom_components/flichub/cover.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from pyflichub.flichub import FlicHubInfo
 
 from . import FlicHubEntryData
-from .const import DOMAIN, DATA_BUTTONS, DATA_HUB, DATA_VIRTUAL_DEVICES
+from .const import DOMAIN, DATA_BUTTONS, DATA_HUB, DATA_VIRTUAL_DEVICES, get_button_by_id
 from .const import EVENT_VIRTUAL_DEVICE_UPDATE, EVENT_DATA_META_DATA, EVENT_DATA_VALUES
 from .entity import FlicHubButtonEntity
 
@@ -27,13 +27,14 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
         if device_info.get("dimmable_type") == "Blind":
             button_id = device_info.get("button_id")
             virtual_device_id = device_info.get("virtual_device_id")
-            if button_id in data_entry.coordinator.data[DATA_BUTTONS]:
+            button = get_button_by_id(data_entry.coordinator.data[DATA_BUTTONS], button_id)
+            if button:
                 devices.append(
                     FlicHubVirtualBlind(
                         hass,
                         data_entry.coordinator,
                         entry,
-                        button_id,
+                        button.serial_number,
                         virtual_device_id,
                         flic_hub
                     )
@@ -47,13 +48,14 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
         if device_info.get("dimmable_type") == "Blind":
             button_id = device_info.get("button_id")
             virtual_device_id = device_info.get("virtual_device_id")
-            if button_id in data_entry.coordinator.data[DATA_BUTTONS]:
+            button = get_button_by_id(data_entry.coordinator.data[DATA_BUTTONS], button_id)
+            if button:
                 async_add_devices([
                     FlicHubVirtualBlind(
                         hass,
                         data_entry.coordinator,
                         entry,
-                        button_id,
+                        button.serial_number,
                         virtual_device_id,
                         flic_hub
                     )
@@ -96,7 +98,7 @@ class FlicHubVirtualBlind(FlicHubButtonEntity, CoverEntity):
         button_id = meta_data.get("button_id")
         virtual_device_id = meta_data.get("virtual_device_id")
 
-        if button_id != self.serial_number or virtual_device_id != self._virtual_device_id:
+        if button_id not in [self.serial_number, self.button.bdaddr] or virtual_device_id != self._virtual_device_id:
             return
 
         values = event.data.get(EVENT_DATA_VALUES, {})

--- a/custom_components/flichub/light.py
+++ b/custom_components/flichub/light.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from pyflichub.flichub import FlicHubInfo
 
 from . import FlicHubEntryData
-from .const import DOMAIN, DATA_BUTTONS, DATA_HUB, DATA_VIRTUAL_DEVICES
+from .const import DOMAIN, DATA_BUTTONS, DATA_HUB, DATA_VIRTUAL_DEVICES, get_button_by_id
 from .const import EVENT_VIRTUAL_DEVICE_UPDATE, EVENT_DATA_META_DATA, EVENT_DATA_VALUES
 from .entity import FlicHubButtonEntity
 
@@ -27,13 +27,14 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
         if device_info.get("dimmable_type") == "Light":
             button_id = device_info.get("button_id")
             virtual_device_id = device_info.get("virtual_device_id")
-            if button_id in data_entry.coordinator.data[DATA_BUTTONS]:
+            button = get_button_by_id(data_entry.coordinator.data[DATA_BUTTONS], button_id)
+            if button:
                 devices.append(
                     FlicHubVirtualLight(
                         hass,
                         data_entry.coordinator,
                         entry,
-                        button_id,
+                        button.serial_number,
                         virtual_device_id,
                         flic_hub
                     )
@@ -47,13 +48,14 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
         if device_info.get("dimmable_type") == "Light":
             button_id = device_info.get("button_id")
             virtual_device_id = device_info.get("virtual_device_id")
-            if button_id in data_entry.coordinator.data[DATA_BUTTONS]:
+            button = get_button_by_id(data_entry.coordinator.data[DATA_BUTTONS], button_id)
+            if button:
                 async_add_devices([
                     FlicHubVirtualLight(
                         hass,
                         data_entry.coordinator,
                         entry,
-                        button_id,
+                        button.serial_number,
                         virtual_device_id,
                         flic_hub
                     )
@@ -99,7 +101,7 @@ class FlicHubVirtualLight(FlicHubButtonEntity, LightEntity):
         button_id = meta_data.get("button_id")
         virtual_device_id = meta_data.get("virtual_device_id")
 
-        if button_id != self.serial_number or virtual_device_id != self._virtual_device_id:
+        if button_id not in [self.serial_number, self.button.bdaddr] or virtual_device_id != self._virtual_device_id:
             return
 
         values = event.data.get(EVENT_DATA_VALUES, {})

--- a/custom_components/flichub/media_player.py
+++ b/custom_components/flichub/media_player.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from pyflichub.flichub import FlicHubInfo
 
 from . import FlicHubEntryData
-from .const import DOMAIN, DATA_BUTTONS, DATA_HUB, DATA_VIRTUAL_DEVICES
+from .const import DOMAIN, DATA_BUTTONS, DATA_HUB, DATA_VIRTUAL_DEVICES, get_button_by_id
 from .const import EVENT_VIRTUAL_DEVICE_UPDATE, EVENT_DATA_META_DATA, EVENT_DATA_VALUES
 from .entity import FlicHubButtonEntity
 
@@ -27,13 +27,14 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
         if device_info.get("dimmable_type") == "Speaker":
             button_id = device_info.get("button_id")
             virtual_device_id = device_info.get("virtual_device_id")
-            if button_id in data_entry.coordinator.data[DATA_BUTTONS]:
+            button = get_button_by_id(data_entry.coordinator.data[DATA_BUTTONS], button_id)
+            if button:
                 devices.append(
                     FlicHubVirtualSpeaker(
                         hass,
                         data_entry.coordinator,
                         entry,
-                        button_id,
+                        button.serial_number,
                         virtual_device_id,
                         flic_hub
                     )
@@ -47,13 +48,14 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
         if device_info.get("dimmable_type") == "Speaker":
             button_id = device_info.get("button_id")
             virtual_device_id = device_info.get("virtual_device_id")
-            if button_id in data_entry.coordinator.data[DATA_BUTTONS]:
+            button = get_button_by_id(data_entry.coordinator.data[DATA_BUTTONS], button_id)
+            if button:
                 async_add_devices([
                     FlicHubVirtualSpeaker(
                         hass,
                         data_entry.coordinator,
                         entry,
-                        button_id,
+                        button.serial_number,
                         virtual_device_id,
                         flic_hub
                     )
@@ -97,7 +99,7 @@ class FlicHubVirtualSpeaker(FlicHubButtonEntity, MediaPlayerEntity):
         button_id = meta_data.get("button_id")
         virtual_device_id = meta_data.get("virtual_device_id")
 
-        if button_id != self.serial_number or virtual_device_id != self._virtual_device_id:
+        if button_id not in [self.serial_number, self.button.bdaddr] or virtual_device_id != self._virtual_device_id:
             return
 
         values = event.data.get(EVENT_DATA_VALUES, {})


### PR DESCRIPTION
Flic virtual devices (lights, speakers, blinds) were failing to initialize because the `button_id` payload inside the `virtualDeviceUpdate` event contains the physical button's MAC address (`bdaddr`), but the entities expect a `serial_number`. This PR introduces a helper to resolve the actual Flic button object by `bdaddr` during setup, enabling proper creation and event filtering for dynamic virtual devices.

---
*PR created automatically by Jules for task [5464096097954341212](https://jules.google.com/task/5464096097954341212) started by @JohNan*