### PR TITLE
Fix integration reload crash on virtual device creation

### DIFF
--- a/custom_components/flichub/__init__.py
+++ b/custom_components/flichub/__init__.py
@@ -7,6 +7,7 @@ https://github.com/JohNan/flichub
 import async_timeout
 import asyncio
 import logging
+from typing import Any
 from dataclasses import dataclass
 from datetime import timedelta
 from homeassistant.helpers.issue_registry import async_create_issue, IssueSeverity
@@ -40,6 +41,7 @@ class FlicHubEntryData:
 
     client: FlicHubTcpClient
     coordinator: DataUpdateCoordinator[dict]
+    unsub_update_listener: Any = None
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
@@ -86,6 +88,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             virtual_device_id = event.meta_data.get("virtual_device_id")
             dimmable_type = event.meta_data.get("dimmable_type")
 
+            _LOGGER.debug(f"virtualDeviceUpdate received: button_id={button_id}, virtual_device_id={virtual_device_id}, dimmable_type={dimmable_type}, values={event.values}")
+
             # Persist and dispatch creation if not already created
             if button_id and virtual_device_id and dimmable_type:
                 # Add it to the config entry options (or data)
@@ -101,15 +105,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 exists = any(d.get("button_id") == button_id and d.get("virtual_device_id") == virtual_device_id for d in virtual_devices)
 
                 if not exists:
+                    _LOGGER.debug(f"Adding new virtual device to config entry: {new_device}")
                     # Update config entry
                     new_virtual_devices = virtual_devices + [new_device]
                     new_data = dict(entry.data)
                     new_data[DATA_VIRTUAL_DEVICES] = new_virtual_devices
+
+                    # Temporarily unsubscribe to avoid full integration reload on config entry update
+                    data_entry = hass.data[DOMAIN].get(entry.entry_id)
+                    if data_entry and data_entry.unsub_update_listener:
+                        data_entry.unsub_update_listener()
+
                     hass.config_entries.async_update_entry(entry, data=new_data)
 
+                    # Re-subscribe
+                    if data_entry:
+                        data_entry.unsub_update_listener = entry.add_update_listener(async_reload_entry)
+
                     # Dispatch to platform setup
+                    _LOGGER.debug(f"Dispatching virtual device creation for {virtual_device_id}")
                     from homeassistant.helpers.dispatcher import async_dispatcher_send
                     async_dispatcher_send(hass, f"{DOMAIN}_{entry.entry_id}_add_virtual_device", new_device)
+                else:
+                    _LOGGER.debug(f"Virtual device {virtual_device_id} for button {button_id} already exists in config.")
 
             hass.bus.fire(EVENT_VIRTUAL_DEVICE_UPDATE, {
                 EVENT_DATA_META_DATA: event.meta_data,
@@ -182,7 +200,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_client)
 
     try:
-        with async_timeout.timeout(CLIENT_READY_TIMEOUT):
+        async with asyncio.timeout(CLIENT_READY_TIMEOUT):
             await client_ready.wait()
     except asyncio.TimeoutError:
         _LOGGER.error(f"Client not connected after {CLIENT_READY_TIMEOUT} secs. Discontinuing setup")
@@ -222,14 +240,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             model="LR",
         )
 
-    hass.data[DOMAIN][entry.entry_id] = FlicHubEntryData(
+    data = FlicHubEntryData(
         client=client,
         coordinator=coordinator
     )
 
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    data.unsub_update_listener = entry.add_update_listener(async_reload_entry)
+    hass.data[DOMAIN][entry.entry_id] = data
 
-    entry.add_update_listener(async_reload_entry)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async def send_virtual_device_update_state(call):
         """Service to send virtual device update state to Flic Hub."""

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,3 @@
-homeassistant
-pyflichub-tcpclient
+pytest
+pytest-asyncio
+pytest-homeassistant-custom-component

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Enable custom integrations in testing."""
+    yield

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,89 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntryState
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.flichub.const import DOMAIN, DATA_VIRTUAL_DEVICES
+from pyflichub.event import Event
+
+@pytest.fixture
+def mock_flichub_client():
+    with patch("custom_components.flichub.FlicHubTcpClient") as mock_client:
+        client_instance = mock_client.return_value
+        client_instance.get_server_info = AsyncMock()
+        client_instance.get_buttons = AsyncMock(return_value=[])
+        hub_info = MagicMock()
+        hub_info.has_wifi.return_value = True
+        hub_info.wifi.ip = "192.168.1.64"
+        hub_info.wifi.mac = "11:22:33:44:55:66"
+        hub_info.has_ethernet.return_value = False
+        client_instance.get_hubinfo = AsyncMock(return_value=hub_info)
+        client_instance.async_connect = AsyncMock()
+        client_instance.disconnect = MagicMock()
+        yield client_instance
+
+async def test_virtual_device_update_does_not_reload(hass: HomeAssistant, mock_flichub_client):
+    """Test that virtual device update does not reload the integration."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Flic Hub",
+        data={"ip_address": "192.168.1.64", "port": "8124"},
+    )
+    config_entry.add_to_hass(hass)
+
+    # Set up the integration
+    with patch("custom_components.flichub.CLIENT_READY_TIMEOUT", 0.1):
+        # We need to simulate the client ready event immediately to avoid waiting timeout
+        async def mock_connect(*args, **kwargs):
+            await mock_flichub_client.async_on_connected()
+        mock_flichub_client.async_connect.side_effect = mock_connect
+
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state == ConfigEntryState.LOADED
+
+    # Get the client instance to simulate an event
+    data_entry = hass.data[DOMAIN][config_entry.entry_id]
+
+    # Check that our update listener is set
+    assert data_entry.unsub_update_listener is not None
+
+    # Store old reload function reference to ensure it's not called
+    with patch("custom_components.flichub.async_reload_entry") as mock_reload:
+        # Simulate a virtualDeviceUpdate event
+        event_data = {
+            "event": "virtualDeviceUpdate",
+            "meta_data": {
+                "button_id": "90:88:a9:5b:12:89",
+                "virtual_device_id": "Virtual Light",
+                "dimmable_type": "Light"
+            },
+            "values": {
+                "brightness": 0.91
+            }
+        }
+        event = Event(event_data["event"])
+        event.meta_data = event_data["meta_data"]
+        event.values = event_data["values"]
+
+        # Get the callback that was attached to the mocked client
+        import sys
+        flichub_client_mock_class = sys.modules['custom_components.flichub'].FlicHubTcpClient
+        on_event = flichub_client_mock_class.call_args.kwargs.get("event_callback")
+
+        on_event(None, event)
+        await hass.async_block_till_done()
+
+        # Config entry data should be updated with the virtual device
+        assert DATA_VIRTUAL_DEVICES in config_entry.data
+        assert len(config_entry.data[DATA_VIRTUAL_DEVICES]) == 1
+        assert config_entry.data[DATA_VIRTUAL_DEVICES][0]["virtual_device_id"] == "Virtual Light"
+
+        # The reload method should NOT have been called due to our fix
+        mock_reload.assert_not_called()
+
+        # Data entry listener should be re-subscribed
+        assert data_entry.unsub_update_listener is not None


### PR DESCRIPTION
The integration previously crashed when a `virtualDeviceUpdate` event created a new virtual device. The root cause was that appending the new device to `entry.data` and calling `hass.config_entries.async_update_entry()` triggered the registered `async_reload_entry` listener. This caused Home Assistant to prematurely unload the integration while platform setup tasks were still pending, resulting in a "Task was destroyed but it is pending" error.

This PR fixes the issue by temporarily unsubscribing the update listener before updating the config entry data, and resubscribing it immediately afterwards. The commit also adds debug logs around the virtual device event handling to aid in future troubleshooting, as requested by the user, and introduces a unit test using `pytest-homeassistant-custom-component` to verify the fix.

---
*PR created automatically by Jules for task [10814388998217660787](https://jules.google.com/task/10814388998217660787) started by @JohNan*