### PR TITLE
Throttle virtual device updates

### DIFF
--- a/custom_components/flichub/cover.py
+++ b/custom_components/flichub/cover.py
@@ -85,6 +85,9 @@ class FlicHubVirtualBlind(FlicHubButtonEntity, CoverEntity):
         # State
         self._position = 100 # Default open
 
+        self._latest_values = {}
+        self._update_timer = None
+
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
@@ -105,6 +108,17 @@ class FlicHubVirtualBlind(FlicHubButtonEntity, CoverEntity):
 
         # The values themselves are always floating point numbers between 0 and 1
         # Extract and convert values
+        self._latest_values.update(values)
+
+        if self._update_timer is None:
+            self._update_timer = self.hass.loop.call_later(0.1, self._apply_latest_values)
+
+    def _apply_latest_values(self):
+        """Apply the latest values and update HA state."""
+        self._update_timer = None
+        values = self._latest_values
+        self._latest_values = {}
+
         if "position" in values:
             self._position = int(values["position"] * 100)
 

--- a/custom_components/flichub/light.py
+++ b/custom_components/flichub/light.py
@@ -88,6 +88,9 @@ class FlicHubVirtualLight(FlicHubButtonEntity, LightEntity):
         self._hs_color = None
         self._color_temp = None
 
+        self._latest_values = {}
+        self._update_timer = None
+
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
@@ -108,6 +111,17 @@ class FlicHubVirtualLight(FlicHubButtonEntity, LightEntity):
 
         # The values themselves are always floating point numbers between 0 and 1
         # Extract and convert values
+        self._latest_values.update(values)
+
+        if self._update_timer is None:
+            self._update_timer = self.hass.loop.call_later(0.1, self._apply_latest_values)
+
+    def _apply_latest_values(self):
+        """Apply the latest values and update HA state."""
+        self._update_timer = None
+        values = self._latest_values
+        self._latest_values = {}
+
         if "brightness" in values:
             self._brightness = int(values["brightness"] * 255)
             self._is_on = self._brightness > 0

--- a/custom_components/flichub/media_player.py
+++ b/custom_components/flichub/media_player.py
@@ -86,6 +86,9 @@ class FlicHubVirtualSpeaker(FlicHubButtonEntity, MediaPlayerEntity):
         self._volume_level = 0.5
         self._state = MediaPlayerState.PLAYING
 
+        self._latest_values = {}
+        self._update_timer = None
+
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
@@ -106,6 +109,17 @@ class FlicHubVirtualSpeaker(FlicHubButtonEntity, MediaPlayerEntity):
 
         # The values themselves are always floating point numbers between 0 and 1
         # Extract and convert values
+        self._latest_values.update(values)
+
+        if self._update_timer is None:
+            self._update_timer = self.hass.loop.call_later(0.1, self._apply_latest_values)
+
+    def _apply_latest_values(self):
+        """Apply the latest values and update HA state."""
+        self._update_timer = None
+        values = self._latest_values
+        self._latest_values = {}
+
         if "volume" in values:
             self._volume_level = float(values["volume"])
 


### PR DESCRIPTION
Fixes an issue where virtual device sliders jump around uncontrollably due to excessive data rates sent from the Flic Hub during Twist rotation.

---
*PR created automatically by Jules for task [17769580375343986549](https://jules.google.com/task/17769580375343986549) started by @JohNan*