### PR TITLE
feat: implement RateDetentController for virtual devices

### DIFF
--- a/custom_components/flichub/cover.py
+++ b/custom_components/flichub/cover.py
@@ -7,6 +7,7 @@ from homeassistant.core import HomeAssistant, Event
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from pyflichub.flichub import FlicHubInfo
+from pyflichub.twist_controller import RateDetentController
 
 from . import FlicHubEntryData
 from .const import DOMAIN, DATA_BUTTONS, DATA_HUB, DATA_VIRTUAL_DEVICES, get_button_by_id
@@ -84,6 +85,15 @@ class FlicHubVirtualBlind(FlicHubButtonEntity, CoverEntity):
 
         # State
         self._position = 100 # Default open
+        self._position_controller = RateDetentController(
+            cfg={"minOutPct": 0, "maxOutPct": 100},
+            on_change_callback=self._on_position_change
+        )
+
+    def _on_position_change(self, new_position_pct: int) -> None:
+        """Handle smoothed position changes from the RateDetentController."""
+        self._position = new_position_pct
+        self.schedule_update_ha_state()
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
@@ -91,6 +101,12 @@ class FlicHubVirtualBlind(FlicHubButtonEntity, CoverEntity):
         self.async_on_remove(
             self.hass.bus.async_listen(EVENT_VIRTUAL_DEVICE_UPDATE, self._event_callback)
         )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        await super().async_will_remove_from_hass()
+        if self._position_controller:
+            self._position_controller.stop()
 
     def _event_callback(self, event: Event):
         """Handle virtual device update event."""
@@ -106,7 +122,7 @@ class FlicHubVirtualBlind(FlicHubButtonEntity, CoverEntity):
         # The values themselves are always floating point numbers between 0 and 1
         # Extract and convert values
         if "position" in values:
-            self._position = int(values["position"] * 100)
+            self._position_controller.update_raw(values["position"] * 100)
 
         self.schedule_update_ha_state()
 
@@ -128,5 +144,6 @@ class FlicHubVirtualBlind(FlicHubButtonEntity, CoverEntity):
         client = self.coordinator.hass.data[DOMAIN][self.config_entry.entry_id].client
         values = {"position": position / 100.0}
         self._position = position
+        self._position_controller.actual_out_pct = position
         client.send_virtual_device_update_state("Blind", self._virtual_device_id, values)
         self.async_write_ha_state()

--- a/custom_components/flichub/light.py
+++ b/custom_components/flichub/light.py
@@ -7,6 +7,7 @@ from homeassistant.core import HomeAssistant, Event
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from pyflichub.flichub import FlicHubInfo
+from pyflichub.twist_controller import RateDetentController
 
 from . import FlicHubEntryData
 from .const import DOMAIN, DATA_BUTTONS, DATA_HUB, DATA_VIRTUAL_DEVICES, get_button_by_id
@@ -87,6 +88,16 @@ class FlicHubVirtualLight(FlicHubButtonEntity, LightEntity):
         self._brightness = 255
         self._hs_color = None
         self._color_temp = None
+        self._brightness_controller = RateDetentController(
+            cfg={"minOutPct": 0, "maxOutPct": 100},
+            on_change_callback=self._on_brightness_change
+        )
+
+    def _on_brightness_change(self, new_brightness_pct: int) -> None:
+        """Handle smoothed brightness changes from the RateDetentController."""
+        self._brightness = int((new_brightness_pct / 100.0) * 255)
+        self._is_on = self._brightness > 0
+        self.schedule_update_ha_state()
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
@@ -94,6 +105,12 @@ class FlicHubVirtualLight(FlicHubButtonEntity, LightEntity):
         self.async_on_remove(
             self.hass.bus.async_listen(EVENT_VIRTUAL_DEVICE_UPDATE, self._event_callback)
         )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        await super().async_will_remove_from_hass()
+        if self._brightness_controller:
+            self._brightness_controller.stop()
 
     def _event_callback(self, event: Event):
         """Handle virtual device update event."""
@@ -109,8 +126,7 @@ class FlicHubVirtualLight(FlicHubButtonEntity, LightEntity):
         # The values themselves are always floating point numbers between 0 and 1
         # Extract and convert values
         if "brightness" in values:
-            self._brightness = int(values["brightness"] * 255)
-            self._is_on = self._brightness > 0
+            self._brightness_controller.update_raw(values["brightness"] * 100)
 
         if "hue" in values and "saturation" in values:
             self._hs_color = (values["hue"] * 360, values["saturation"] * 100)
@@ -154,9 +170,11 @@ class FlicHubVirtualLight(FlicHubButtonEntity, LightEntity):
         if "brightness" in kwargs:
             values["brightness"] = kwargs["brightness"] / 255.0
             self._brightness = kwargs["brightness"]
+            self._brightness_controller.actual_out_pct = values["brightness"] * 100
         else:
             values["brightness"] = self._brightness / 255.0 if self._brightness else 1.0
             self._brightness = self._brightness if self._brightness else 255
+            self._brightness_controller.actual_out_pct = values["brightness"] * 100
 
         if "hs_color" in kwargs:
             values["hue"] = kwargs["hs_color"][0] / 360.0
@@ -177,5 +195,6 @@ class FlicHubVirtualLight(FlicHubButtonEntity, LightEntity):
         client = self.coordinator.hass.data[DOMAIN][self.config_entry.entry_id].client
         values = {"brightness": 0.0}
         self._is_on = False
+        self._brightness_controller.actual_out_pct = 0.0
         client.send_virtual_device_update_state("Light", self._virtual_device_id, values)
         self.async_write_ha_state()

--- a/custom_components/flichub/manifest.json
+++ b/custom_components/flichub/manifest.json
@@ -17,6 +17,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/JohNan/home-assistant-flichub/issues",
   "loggers": ["pyflichub"],
-  "requirements": ["pyflichub-tcpclient==0.1.15"],
+  "requirements": ["pyflichub-tcpclient==0.1.16"],
   "version": "v0.0.0"
 }

--- a/custom_components/flichub/media_player.py
+++ b/custom_components/flichub/media_player.py
@@ -7,6 +7,7 @@ from homeassistant.core import HomeAssistant, Event
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from pyflichub.flichub import FlicHubInfo
+from pyflichub.twist_controller import RateDetentController
 
 from . import FlicHubEntryData
 from .const import DOMAIN, DATA_BUTTONS, DATA_HUB, DATA_VIRTUAL_DEVICES, get_button_by_id
@@ -85,6 +86,15 @@ class FlicHubVirtualSpeaker(FlicHubButtonEntity, MediaPlayerEntity):
         # State
         self._volume_level = 0.5
         self._state = MediaPlayerState.PLAYING
+        self._volume_controller = RateDetentController(
+            cfg={"minOutPct": 0, "maxOutPct": 100},
+            on_change_callback=self._on_volume_change
+        )
+
+    def _on_volume_change(self, new_volume_pct: int) -> None:
+        """Handle smoothed volume changes from the RateDetentController."""
+        self._volume_level = new_volume_pct / 100.0
+        self.schedule_update_ha_state()
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
@@ -92,6 +102,12 @@ class FlicHubVirtualSpeaker(FlicHubButtonEntity, MediaPlayerEntity):
         self.async_on_remove(
             self.hass.bus.async_listen(EVENT_VIRTUAL_DEVICE_UPDATE, self._event_callback)
         )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        await super().async_will_remove_from_hass()
+        if self._volume_controller:
+            self._volume_controller.stop()
 
     def _event_callback(self, event: Event):
         """Handle virtual device update event."""
@@ -107,7 +123,7 @@ class FlicHubVirtualSpeaker(FlicHubButtonEntity, MediaPlayerEntity):
         # The values themselves are always floating point numbers between 0 and 1
         # Extract and convert values
         if "volume" in values:
-            self._volume_level = float(values["volume"])
+            self._volume_controller.update_raw(values["volume"] * 100)
 
         self.schedule_update_ha_state()
 
@@ -126,5 +142,6 @@ class FlicHubVirtualSpeaker(FlicHubButtonEntity, MediaPlayerEntity):
         client = self.coordinator.hass.data[DOMAIN][self.config_entry.entry_id].client
         values = {"volume": volume}
         self._volume_level = volume
+        self._volume_controller.actual_out_pct = volume * 100
         client.send_virtual_device_update_state("Speaker", self._virtual_device_id, values)
         self.async_write_ha_state()


### PR DESCRIPTION
This implements `RateDetentController` from `pyflichub.twist_controller` to smooth out Flic Twist rotation updates in virtual devices (Light, Media Player, Cover). It bumps the dependency of `pyflichub-tcpclient` to `0.1.16`.

---
*PR created automatically by Jules for task [5868927475633433971](https://jules.google.com/task/5868927475633433971) started by @JohNan*