### PR TITLE
Fix RateDetentController event loop RuntimeError

### DIFF
--- a/custom_components/flichub/cover.py
+++ b/custom_components/flichub/cover.py
@@ -87,7 +87,8 @@ class FlicHubVirtualBlind(FlicHubButtonEntity, CoverEntity):
         self._position = 100 # Default open
         self._position_controller = RateDetentController(
             cfg={"minOutPct": 0, "maxOutPct": 100},
-            on_change_callback=self._on_position_change
+            on_change_callback=self._on_position_change,
+            loop=hass.loop
         )
 
     def _on_position_change(self, new_position_pct: int) -> None:

--- a/custom_components/flichub/light.py
+++ b/custom_components/flichub/light.py
@@ -90,7 +90,8 @@ class FlicHubVirtualLight(FlicHubButtonEntity, LightEntity):
         self._color_temp = None
         self._brightness_controller = RateDetentController(
             cfg={"minOutPct": 0, "maxOutPct": 100},
-            on_change_callback=self._on_brightness_change
+            on_change_callback=self._on_brightness_change,
+            loop=hass.loop
         )
 
     def _on_brightness_change(self, new_brightness_pct: int) -> None:

--- a/custom_components/flichub/manifest.json
+++ b/custom_components/flichub/manifest.json
@@ -17,6 +17,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/JohNan/home-assistant-flichub/issues",
   "loggers": ["pyflichub"],
-  "requirements": ["pyflichub-tcpclient==0.1.16"],
+  "requirements": ["pyflichub-tcpclient @ git+https://github.com/JohNan/pyflichub-tcpclient.git@7b529a16e525b0b6258e9e409e436babf7acde14"],
   "version": "v0.0.0"
 }

--- a/custom_components/flichub/manifest.json
+++ b/custom_components/flichub/manifest.json
@@ -17,6 +17,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/JohNan/home-assistant-flichub/issues",
   "loggers": ["pyflichub"],
-  "requirements": ["pyflichub-tcpclient @ git+https://github.com/JohNan/pyflichub-tcpclient.git@7b529a16e525b0b6258e9e409e436babf7acde14"],
+  "requirements": ["pyflichub-tcpclient==0.1.17"],
   "version": "v0.0.0"
 }

--- a/custom_components/flichub/media_player.py
+++ b/custom_components/flichub/media_player.py
@@ -88,7 +88,8 @@ class FlicHubVirtualSpeaker(FlicHubButtonEntity, MediaPlayerEntity):
         self._state = MediaPlayerState.PLAYING
         self._volume_controller = RateDetentController(
             cfg={"minOutPct": 0, "maxOutPct": 100},
-            on_change_callback=self._on_volume_change
+            on_change_callback=self._on_volume_change,
+            loop=hass.loop
         )
 
     def _on_volume_change(self, new_volume_pct: int) -> None:


### PR DESCRIPTION
Fixes a crash when updating twist states by providing `hass.loop` to `RateDetentController`. 

Includes an update to `pyflichub-tcpclient` pinned to a specific commit that incorporates the fix to support thread-safe task creation.

---
*PR created automatically by Jules for task [16217822707766255520](https://jules.google.com/task/16217822707766255520) started by @JohNan*