### PR TITLE
Add Flic Duo device triggers for specific button presses

### DIFF
--- a/custom_components/flichub/const.py
+++ b/custom_components/flichub/const.py
@@ -4,6 +4,7 @@ from homeassistant.const import Platform
 # Base component constants
 NAME = "Flic Hub"
 DOMAIN = "flichub"
+CONF_SUBTYPE = "subtype"
 DOMAIN_DATA = f"{DOMAIN}_data"
 VERSION = "0.0.0"
 REQUIRED_SERVER_VERSION = "0.1.13"

--- a/custom_components/flichub/device_trigger.py
+++ b/custom_components/flichub/device_trigger.py
@@ -9,11 +9,11 @@ from homeassistant.const import (
     CONF_TYPE,
 )
 from homeassistant.core import HomeAssistant, CALLBACK_TYPE
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import config_validation as cv, device_registry as dr, entity_registry as er
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.components.homeassistant.triggers import event as event_trigger
 
-from .const import DOMAIN, EVENT_CLICK, EVENT_DATA_CLICK_TYPE, EVENT_DATA_SERIAL_NUMBER
+from .const import DOMAIN, EVENT_CLICK, EVENT_DATA_CLICK_TYPE, EVENT_DATA_SERIAL_NUMBER, CONF_SUBTYPE, EVENT_DATA_BUTTON_NUMBER
 
 # The trigger types that a button can emit
 TRIGGER_TYPES = {"single", "double", "hold", "down", "up", "double_hold"}
@@ -21,6 +21,7 @@ TRIGGER_TYPES = {"single", "double", "hold", "down", "up", "double_hold"}
 TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
+        vol.Optional(CONF_SUBTYPE): cv.string,
     }
 )
 
@@ -41,15 +42,42 @@ async def async_get_triggers(
     if is_hub:
         return []
 
-    return [
-        {
-            CONF_PLATFORM: "device",
-            CONF_DOMAIN: DOMAIN,
-            CONF_DEVICE_ID: device_id,
-            CONF_TYPE: trigger_type,
-        }
-        for trigger_type in TRIGGER_TYPES
-    ]
+    triggers = []
+
+    # Check if this device has been pressed with a button_number (like Flic Duo)
+    entity_registry = er.async_get(hass)
+    entries = er.async_entries_for_device(entity_registry, device_id)
+
+    has_buttons = False
+    for entry in entries:
+        if entry.domain == "binary_sensor":
+            state = hass.states.get(entry.entity_id)
+            if state and state.attributes.get("button_number") is not None:
+                has_buttons = True
+                break
+
+    for trigger_type in TRIGGER_TYPES:
+        triggers.append(
+            {
+                CONF_PLATFORM: "device",
+                CONF_DOMAIN: DOMAIN,
+                CONF_DEVICE_ID: device_id,
+                CONF_TYPE: trigger_type,
+            }
+        )
+        if has_buttons:
+            for button_idx in range(4):
+                triggers.append(
+                    {
+                        CONF_PLATFORM: "device",
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_DEVICE_ID: device_id,
+                        CONF_TYPE: trigger_type,
+                        CONF_SUBTYPE: f"button_{button_idx}",
+                    }
+                )
+
+    return triggers
 
 
 async def async_attach_trigger(
@@ -81,14 +109,21 @@ async def async_attach_trigger(
 
     trigger_type = config[CONF_TYPE]
 
+    event_data = {
+        EVENT_DATA_SERIAL_NUMBER: serial_number,
+        EVENT_DATA_CLICK_TYPE: trigger_type,
+    }
+
+    if CONF_SUBTYPE in config:
+        button_str = config[CONF_SUBTYPE]
+        if button_str.startswith("button_"):
+            event_data[EVENT_DATA_BUTTON_NUMBER] = int(button_str.split("_")[1])
+
     # Listen for the corresponding EVENT_CLICK
     event_config = event_trigger.TRIGGER_SCHEMA({
         event_trigger.CONF_PLATFORM: "event",
         event_trigger.CONF_EVENT_TYPE: EVENT_CLICK,
-        event_trigger.CONF_EVENT_DATA: {
-            EVENT_DATA_SERIAL_NUMBER: serial_number,
-            EVENT_DATA_CLICK_TYPE: trigger_type,
-        },
+        event_trigger.CONF_EVENT_DATA: event_data,
     })
 
     return await event_trigger.async_attach_trigger(

--- a/custom_components/flichub/strings.json
+++ b/custom_components/flichub/strings.json
@@ -43,6 +43,12 @@
       "down": "Button down",
       "up": "Button up",
       "double_hold": "Double click and hold"
+    },
+    "trigger_subtype": {
+      "button_0": "Button 1",
+      "button_1": "Button 2",
+      "button_2": "Button 3",
+      "button_3": "Button 4"
     }
   }
 }

--- a/custom_components/flichub/translations/en.json
+++ b/custom_components/flichub/translations/en.json
@@ -43,6 +43,12 @@
       "down": "Button down",
       "up": "Button up",
       "double_hold": "Double click and hold"
+    },
+    "trigger_subtype": {
+      "button_0": "Button 1",
+      "button_1": "Button 2",
+      "button_2": "Button 3",
+      "button_3": "Button 4"
     }
   }
 }


### PR DESCRIPTION
The Flic Duo multi-button events provide a `button_number` attribute on the binary sensor. This PR updates the device automation triggers to optionally filter by `button_number` (using `CONF_SUBTYPE`). Since we only know it's a multi-button device once a button is pressed, the triggers for `button_X` are conditionally yielded based on whether the entity state has recorded a `button_number`. Translating subtypes are also added for Home Assistant UI support.

---
*PR created automatically by Jules for task [4039251425591319999](https://jules.google.com/task/4039251425591319999) started by @JohNan*