### PR TITLE
Add Flic Duo multi-button support to device triggers

### DIFF
--- a/custom_components/flichub/device_trigger.py
+++ b/custom_components/flichub/device_trigger.py
@@ -9,18 +9,20 @@ from homeassistant.const import (
     CONF_TYPE,
 )
 from homeassistant.core import HomeAssistant, CALLBACK_TYPE
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import config_validation as cv, device_registry as dr, entity_registry as er
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.components.homeassistant.triggers import event as event_trigger
 
-from .const import DOMAIN, EVENT_CLICK, EVENT_DATA_CLICK_TYPE, EVENT_DATA_SERIAL_NUMBER
+import re
+
+from .const import DOMAIN, EVENT_CLICK, EVENT_DATA_CLICK_TYPE, EVENT_DATA_SERIAL_NUMBER, EVENT_DATA_BUTTON_NUMBER
 
 # The trigger types that a button can emit
 TRIGGER_TYPES = {"single", "double", "hold", "down", "up", "double_hold"}
 
 TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
+        vol.Required(CONF_TYPE): cv.matches_regex(r"^(single|double|hold|down|up|double_hold)(?:_button_(\d+))?$"),
     }
 )
 
@@ -41,7 +43,7 @@ async def async_get_triggers(
     if is_hub:
         return []
 
-    return [
+    triggers = [
         {
             CONF_PLATFORM: "device",
             CONF_DOMAIN: DOMAIN,
@@ -50,6 +52,33 @@ async def async_get_triggers(
         }
         for trigger_type in TRIGGER_TYPES
     ]
+
+    # Flic Duo dynamically populates a button_number when an event with multiple buttons is seen.
+    # To check if this button supports button_number, we can inspect its binary sensor entity.
+    entity_registry = er.async_get(hass)
+    entities = er.async_entries_for_device(entity_registry, device_id)
+    has_multiple_buttons = False
+
+    for entry in entities:
+        if entry.domain == "binary_sensor":
+            state = hass.states.get(entry.entity_id)
+            if state and state.attributes.get("button_number") is not None:
+                has_multiple_buttons = True
+                break
+
+    if has_multiple_buttons:
+        for trigger_type in TRIGGER_TYPES:
+            for button_number in (0, 1):
+                triggers.append(
+                    {
+                        CONF_PLATFORM: "device",
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_DEVICE_ID: device_id,
+                        CONF_TYPE: f"{trigger_type}_button_{button_number}",
+                    }
+                )
+
+    return triggers
 
 
 async def async_attach_trigger(
@@ -79,16 +108,28 @@ async def async_attach_trigger(
     if not serial_number:
         raise ValueError(f"Device {config[CONF_DEVICE_ID]} is missing serial number")
 
-    trigger_type = config[CONF_TYPE]
+    trigger_type_config = config[CONF_TYPE]
+
+    match = re.match(r"^(single|double|hold|down|up|double_hold)(?:_button_(\d+))?$", trigger_type_config)
+    if not match:
+        raise ValueError(f"Invalid trigger type {trigger_type_config}")
+
+    trigger_type = match.group(1)
+    button_number_str = match.group(2)
+
+    event_data = {
+        EVENT_DATA_SERIAL_NUMBER: serial_number,
+        EVENT_DATA_CLICK_TYPE: trigger_type,
+    }
+
+    if button_number_str is not None:
+        event_data[EVENT_DATA_BUTTON_NUMBER] = int(button_number_str)
 
     # Listen for the corresponding EVENT_CLICK
     event_config = event_trigger.TRIGGER_SCHEMA({
         event_trigger.CONF_PLATFORM: "event",
         event_trigger.CONF_EVENT_TYPE: EVENT_CLICK,
-        event_trigger.CONF_EVENT_DATA: {
-            EVENT_DATA_SERIAL_NUMBER: serial_number,
-            EVENT_DATA_CLICK_TYPE: trigger_type,
-        },
+        event_trigger.CONF_EVENT_DATA: event_data,
     })
 
     return await event_trigger.async_attach_trigger(

--- a/custom_components/flichub/strings.json
+++ b/custom_components/flichub/strings.json
@@ -43,18 +43,18 @@
       "down": "Button down",
       "up": "Button up",
       "double_hold": "Double click and hold",
-      "single_button_0": "Single click (Left button)",
-      "double_button_0": "Double click (Left button)",
-      "hold_button_0": "Hold (Left button)",
-      "down_button_0": "Button down (Left button)",
-      "up_button_0": "Button up (Left button)",
-      "double_hold_button_0": "Double click and hold (Left button)",
-      "single_button_1": "Single click (Right button)",
-      "double_button_1": "Double click (Right button)",
-      "hold_button_1": "Hold (Right button)",
-      "down_button_1": "Button down (Right button)",
-      "up_button_1": "Button up (Right button)",
-      "double_hold_button_1": "Double click and hold (Right button)"
+      "single_button_0": "Single click (Large button)",
+      "double_button_0": "Double click (Large button)",
+      "hold_button_0": "Hold (Large button)",
+      "down_button_0": "Button down (Large button)",
+      "up_button_0": "Button up (Large button)",
+      "double_hold_button_0": "Double click and hold (Large button)",
+      "single_button_1": "Single click (Small button)",
+      "double_button_1": "Double click (Small button)",
+      "hold_button_1": "Hold (Small button)",
+      "down_button_1": "Button down (Small button)",
+      "up_button_1": "Button up (Small button)",
+      "double_hold_button_1": "Double click and hold (Small button)"
     }
   }
 }

--- a/custom_components/flichub/strings.json
+++ b/custom_components/flichub/strings.json
@@ -42,7 +42,19 @@
       "hold": "Hold",
       "down": "Button down",
       "up": "Button up",
-      "double_hold": "Double click and hold"
+      "double_hold": "Double click and hold",
+      "single_button_0": "Single click (Left button)",
+      "double_button_0": "Double click (Left button)",
+      "hold_button_0": "Hold (Left button)",
+      "down_button_0": "Button down (Left button)",
+      "up_button_0": "Button up (Left button)",
+      "double_hold_button_0": "Double click and hold (Left button)",
+      "single_button_1": "Single click (Right button)",
+      "double_button_1": "Double click (Right button)",
+      "hold_button_1": "Hold (Right button)",
+      "down_button_1": "Button down (Right button)",
+      "up_button_1": "Button up (Right button)",
+      "double_hold_button_1": "Double click and hold (Right button)"
     }
   }
 }

--- a/custom_components/flichub/translations/en.json
+++ b/custom_components/flichub/translations/en.json
@@ -43,18 +43,18 @@
       "down": "Button down",
       "up": "Button up",
       "double_hold": "Double click and hold",
-      "single_button_0": "Single click (Left button)",
-      "double_button_0": "Double click (Left button)",
-      "hold_button_0": "Hold (Left button)",
-      "down_button_0": "Button down (Left button)",
-      "up_button_0": "Button up (Left button)",
-      "double_hold_button_0": "Double click and hold (Left button)",
-      "single_button_1": "Single click (Right button)",
-      "double_button_1": "Double click (Right button)",
-      "hold_button_1": "Hold (Right button)",
-      "down_button_1": "Button down (Right button)",
-      "up_button_1": "Button up (Right button)",
-      "double_hold_button_1": "Double click and hold (Right button)"
+      "single_button_0": "Single click (Large button)",
+      "double_button_0": "Double click (Large button)",
+      "hold_button_0": "Hold (Large button)",
+      "down_button_0": "Button down (Large button)",
+      "up_button_0": "Button up (Large button)",
+      "double_hold_button_0": "Double click and hold (Large button)",
+      "single_button_1": "Single click (Small button)",
+      "double_button_1": "Double click (Small button)",
+      "hold_button_1": "Hold (Small button)",
+      "down_button_1": "Button down (Small button)",
+      "up_button_1": "Button up (Small button)",
+      "double_hold_button_1": "Double click and hold (Small button)"
     }
   }
 }

--- a/custom_components/flichub/translations/en.json
+++ b/custom_components/flichub/translations/en.json
@@ -42,7 +42,19 @@
       "hold": "Hold",
       "down": "Button down",
       "up": "Button up",
-      "double_hold": "Double click and hold"
+      "double_hold": "Double click and hold",
+      "single_button_0": "Single click (Left button)",
+      "double_button_0": "Double click (Left button)",
+      "hold_button_0": "Hold (Left button)",
+      "down_button_0": "Button down (Left button)",
+      "up_button_0": "Button up (Left button)",
+      "double_hold_button_0": "Double click and hold (Left button)",
+      "single_button_1": "Single click (Right button)",
+      "double_button_1": "Double click (Right button)",
+      "hold_button_1": "Hold (Right button)",
+      "down_button_1": "Button down (Right button)",
+      "up_button_1": "Button up (Right button)",
+      "double_hold_button_1": "Double click and hold (Right button)"
     }
   }
 }


### PR DESCRIPTION
- Dynamically fetch binary sensor `button_number` attributes via HA entity registry.
- If multiple buttons are detected, append specific triggers for `button_0` and `button_1` (e.g., `single_button_0`).
- Update `TRIGGER_SCHEMA` with a regex match for multi-button `CONF_TYPE` identifiers.
- Add "Left button" and "Right button" translation strings.

---
*PR created automatically by Jules for task [11171355433188338560](https://jules.google.com/task/11171355433188338560) started by @JohNan*