### PR TITLE
feat: Make RateDetentController deadband values configurable

### DIFF
--- a/custom_components/flichub/config_flow.py
+++ b/custom_components/flichub/config_flow.py
@@ -13,6 +13,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.device_registry import format_mac
 from pyflichub.client import FlicHubTcpClient
 from .const import CLIENT_READY_TIMEOUT
+from .const import CONF_DEADBAND_ENTER, CONF_DEADBAND_EXIT
 from .const import DOMAIN
 from .const import PLATFORMS
 
@@ -172,14 +173,16 @@ class FlicHubOptionsFlowHandler(config_entries.OptionsFlow):
             self.options.update(user_input)
             return await self._update_options()
 
+        schema = {
+            vol.Required(x.value, default=self.options.get(x.value, True)): bool
+            for x in sorted(PLATFORMS)
+        }
+        schema[vol.Optional(CONF_DEADBAND_ENTER, default=self.options.get(CONF_DEADBAND_ENTER, 2))] = int
+        schema[vol.Optional(CONF_DEADBAND_EXIT, default=self.options.get(CONF_DEADBAND_EXIT, 5))] = int
+
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(x.value, default=self.options.get(x.value, True)): bool
-                    for x in sorted(PLATFORMS)
-                }
-            ),
+            data_schema=vol.Schema(schema),
         )
 
     async def _update_options(self):

--- a/custom_components/flichub/const.py
+++ b/custom_components/flichub/const.py
@@ -11,6 +11,9 @@ DEFAULT_SCAN_INTERVAL = 60
 
 CLIENT_READY_TIMEOUT = 20.0
 
+CONF_DEADBAND_ENTER = "deadband_enter"
+CONF_DEADBAND_EXIT = "deadband_exit"
+
 # Icons
 ICON = "mdi:format-quote-close"
 

--- a/custom_components/flichub/cover.py
+++ b/custom_components/flichub/cover.py
@@ -10,6 +10,7 @@ from pyflichub.flichub import FlicHubInfo
 from pyflichub.twist_controller import RateDetentController
 
 from . import FlicHubEntryData
+from .const import CONF_DEADBAND_ENTER, CONF_DEADBAND_EXIT
 from .const import DOMAIN, DATA_BUTTONS, DATA_HUB, DATA_VIRTUAL_DEVICES, get_button_by_id
 from .const import EVENT_VIRTUAL_DEVICE_UPDATE, EVENT_DATA_META_DATA, EVENT_DATA_VALUES
 from .entity import FlicHubButtonEntity
@@ -86,7 +87,12 @@ class FlicHubVirtualBlind(FlicHubButtonEntity, CoverEntity):
         # State
         self._position = 100 # Default open
         self._position_controller = RateDetentController(
-            cfg={"minOutPct": 0, "maxOutPct": 100},
+            cfg={
+                "minOutPct": 0,
+                "maxOutPct": 100,
+                "deadbandEnter": config_entry.options.get(CONF_DEADBAND_ENTER, 2),
+                "deadbandExit": config_entry.options.get(CONF_DEADBAND_EXIT, 5),
+            },
             on_change_callback=self._on_position_change,
             loop=hass.loop
         )

--- a/custom_components/flichub/light.py
+++ b/custom_components/flichub/light.py
@@ -10,6 +10,7 @@ from pyflichub.flichub import FlicHubInfo
 from pyflichub.twist_controller import RateDetentController
 
 from . import FlicHubEntryData
+from .const import CONF_DEADBAND_ENTER, CONF_DEADBAND_EXIT
 from .const import DOMAIN, DATA_BUTTONS, DATA_HUB, DATA_VIRTUAL_DEVICES, get_button_by_id
 from .const import EVENT_VIRTUAL_DEVICE_UPDATE, EVENT_DATA_META_DATA, EVENT_DATA_VALUES
 from .entity import FlicHubButtonEntity
@@ -89,7 +90,12 @@ class FlicHubVirtualLight(FlicHubButtonEntity, LightEntity):
         self._hs_color = None
         self._color_temp = None
         self._brightness_controller = RateDetentController(
-            cfg={"minOutPct": 0, "maxOutPct": 100},
+            cfg={
+                "minOutPct": 0,
+                "maxOutPct": 100,
+                "deadbandEnter": config_entry.options.get(CONF_DEADBAND_ENTER, 2),
+                "deadbandExit": config_entry.options.get(CONF_DEADBAND_EXIT, 5),
+            },
             on_change_callback=self._on_brightness_change,
             loop=hass.loop
         )

--- a/custom_components/flichub/media_player.py
+++ b/custom_components/flichub/media_player.py
@@ -10,6 +10,7 @@ from pyflichub.flichub import FlicHubInfo
 from pyflichub.twist_controller import RateDetentController
 
 from . import FlicHubEntryData
+from .const import CONF_DEADBAND_ENTER, CONF_DEADBAND_EXIT
 from .const import DOMAIN, DATA_BUTTONS, DATA_HUB, DATA_VIRTUAL_DEVICES, get_button_by_id
 from .const import EVENT_VIRTUAL_DEVICE_UPDATE, EVENT_DATA_META_DATA, EVENT_DATA_VALUES
 from .entity import FlicHubButtonEntity
@@ -87,7 +88,12 @@ class FlicHubVirtualSpeaker(FlicHubButtonEntity, MediaPlayerEntity):
         self._volume_level = 0.5
         self._state = MediaPlayerState.PLAYING
         self._volume_controller = RateDetentController(
-            cfg={"minOutPct": 0, "maxOutPct": 100},
+            cfg={
+                "minOutPct": 0,
+                "maxOutPct": 100,
+                "deadbandEnter": config_entry.options.get(CONF_DEADBAND_ENTER, 2),
+                "deadbandExit": config_entry.options.get(CONF_DEADBAND_EXIT, 5),
+            },
             on_change_callback=self._on_volume_change,
             loop=hass.loop
         )

--- a/custom_components/flichub/strings.json
+++ b/custom_components/flichub/strings.json
@@ -24,7 +24,9 @@
       "user": {
         "data": {
           "binary_sensor": "Binary sensor enabled",
-          "sensor": "Sensor enabled"
+          "sensor": "Sensor enabled",
+          "deadband_enter": "Deadband enter",
+          "deadband_exit": "Deadband exit"
         }
       }
     }

--- a/custom_components/flichub/translations/en.json
+++ b/custom_components/flichub/translations/en.json
@@ -24,7 +24,9 @@
       "user": {
         "data": {
           "binary_sensor": "Binary sensor enabled",
-          "sensor": "Sensor enabled"
+          "sensor": "Sensor enabled",
+          "deadband_enter": "Deadband enter",
+          "deadband_exit": "Deadband exit"
         }
       }
     }


### PR DESCRIPTION
Decreased `deadbandEnter` from 5 to 2 and `deadbandExit` from 9 to 5 in `RateDetentController` config. Made it possible to adjust these values from the config flow options.

---
*PR created automatically by Jules for task [9704508907371686659](https://jules.google.com/task/9704508907371686659) started by @JohNan*