### PR TITLE
docs: generate prompt for pyflichub IR timings update

### DIFF
--- a/pyflichub_prompt.txt
+++ b/pyflichub_prompt.txt
@@ -1,0 +1,50 @@
+Update the `pyflichub-tcpclient` library and the associated `tcpserver.js` Flic Hub script to support playing raw IR timings. This is required to support Home Assistant's `infrared` entity platform, which sends protocol-agnostic timing arrays instead of pre-recorded signal IDs.
+
+### 1. Update `tcpserver.js`
+In the TCP server script running on the Flic Hub, add a handler for a new command called `"play_ir_raw"`. This handler should extract the `"arr"` property from the JSON payload (which will be an array of integers) and pass it directly to the Flic Hub JS SDK's `ir.play()` method.
+
+Example implementation in `tcpserver.js`:
+```javascript
+var ir = require("ir");
+
+// Inside your data event handler where you parse incoming JSON commands:
+if (data.command === "play_ir_raw") {
+    if (data.arr && Array.isArray(data.arr)) {
+        // Create an Uint32Array as required by the Flic Hub SDK
+        var timings = new Uint32Array(data.arr);
+        ir.play(timings, function(error) {
+            if (error) {
+                console.log("IR Play Error: " + error);
+            }
+        });
+    }
+}
+```
+
+### 2. Update `pyflichub-tcpclient`
+In the Python library, update `pyflichub.server_command.ServerCommand` to include the new command:
+```python
+class ServerCommand(StrEnum):
+    # ... existing commands ...
+    PLAY_IR_RAW = "play_ir_raw"
+```
+
+Add a new method `play_ir_raw` to `pyflichub.client.FlicHubTcpClient` to send the new payload:
+```python
+    def play_ir_raw(self, arr: list[int]):
+        """
+        Plays a raw IR signal.
+        The first element of the array should contain a carrier frequency in Hz (usually 38000 Hz).
+        The following elements indicate in microseconds how long each pulse should be active or silent, alternating.
+        """
+        payload = json.dumps({
+            "command": ServerCommand.PLAY_IR_RAW,
+            "arr": arr
+        })
+        if self._transport is not None:
+            self._transport.write(f"{payload}\n".encode())
+        else:
+            _LOGGER.error("Connection seems to be closed.")
+```
+
+Once this is implemented and released, the Home Assistant integration can be safely updated to map `InfraredCommand.get_raw_timings()` to this new API endpoint.


### PR DESCRIPTION
This commit introduces `pyflichub_prompt.txt`, a document generated specifically per user request.

The user asked to add support for the new Home Assistant `infrared` platform entity to the Flic Hub integration. However, the Home Assistant `infrared` platform requires sending arbitrary raw timing data, which the upstream Flic Hub dependency (`pyflichub-tcpclient` and `tcpserver.js`) currently lacks the API for (only supporting pre-recorded `signal_id` strings).

To resolve this blocker, the user requested a prompt to help update the upstream library. This document provides clear, actionable instructions and code snippets for updating both the `tcpserver.js` (to execute `ir.play(arr)`) and the Python client library (to transmit the array over TCP). Once these upstream changes are implemented and released, the integration can safely consume the new API.

---
*PR created automatically by Jules for task [3556561828821935699](https://jules.google.com/task/3556561828821935699) started by @JohNan*