### PR TITLE
Add native hold release triggers for Flic button automation

### DIFF
--- a/custom_components/flichub/__init__.py
+++ b/custom_components/flichub/__init__.py
@@ -49,6 +49,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     if hass.data.get(DOMAIN) is None:
         hass.data.setdefault(DOMAIN, {})
 
+    button_state = {}
+
     def update_device_registry_names(buttons):
         device_registry = dr.async_get(hass)
         for button in buttons:
@@ -65,6 +67,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 EVENT_DATA_CLICK_TYPE: event.action,
                 EVENT_DATA_BUTTON_NUMBER: event.button_number
             })
+
+            last_action = button_state.get(button.serial_number)
+            if event.action == "up":
+                if last_action == "hold":
+                    hass.bus.fire(EVENT_CLICK, {
+                        EVENT_DATA_SERIAL_NUMBER: button.serial_number,
+                        EVENT_DATA_NAME: button.name,
+                        EVENT_DATA_CLICK_TYPE: "hold_release",
+                        EVENT_DATA_BUTTON_NUMBER: event.button_number
+                    })
+                elif last_action == "double_hold":
+                    hass.bus.fire(EVENT_CLICK, {
+                        EVENT_DATA_SERIAL_NUMBER: button.serial_number,
+                        EVENT_DATA_NAME: button.name,
+                        EVENT_DATA_CLICK_TYPE: "double_hold_release",
+                        EVENT_DATA_BUTTON_NUMBER: event.button_number
+                    })
+
+            if event.action in ["single", "double", "hold", "down", "up", "double_hold"]:
+                button_state[button.serial_number] = event.action
         if event.event == "buttonDeleted":
             device_registry = dr.async_get(hass)
             device = device_registry.async_get_device(identifiers={(DOMAIN, event.button)})

--- a/custom_components/flichub/binary_sensor.py
+++ b/custom_components/flichub/binary_sensor.py
@@ -222,7 +222,7 @@ class FlicHubButtonBinarySensor(FlicHubButtonEntity, BinarySensorEntity):
 
         _LOGGER.debug(f"Button {name} clicked: {click_type}, button_number: {button_number}")
 
-        if click_type in ['single', 'double', 'hold', 'double_hold', 'idle']:
+        if click_type in ['single', 'double', 'hold', 'double_hold', 'hold_release', 'double_hold_release', 'idle']:
             self._click_type = click_type
 
         if button_number is not None:

--- a/custom_components/flichub/device_trigger.py
+++ b/custom_components/flichub/device_trigger.py
@@ -18,11 +18,11 @@ import re
 from .const import DOMAIN, EVENT_CLICK, EVENT_DATA_CLICK_TYPE, EVENT_DATA_SERIAL_NUMBER, EVENT_DATA_BUTTON_NUMBER
 
 # The trigger types that a button can emit
-TRIGGER_TYPES = {"single", "double", "hold", "down", "up", "double_hold"}
+TRIGGER_TYPES = {"single", "double", "hold", "hold_release", "down", "up", "double_hold", "double_hold_release"}
 
 TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_TYPE): cv.matches_regex(r"^(single|double|hold|down|up|double_hold)(?:_button_(\d+))?$"),
+        vol.Required(CONF_TYPE): cv.matches_regex(r"^(single|double|hold|hold_release|down|up|double_hold|double_hold_release)(?:_button_(\d+))?$"),
     }
 )
 
@@ -110,7 +110,7 @@ async def async_attach_trigger(
 
     trigger_type_config = config[CONF_TYPE]
 
-    match = re.match(r"^(single|double|hold|down|up|double_hold)(?:_button_(\d+))?$", trigger_type_config)
+    match = re.match(r"^(single|double|hold|hold_release|down|up|double_hold|double_hold_release)(?:_button_(\d+))?$", trigger_type_config)
     if not match:
         raise ValueError(f"Invalid trigger type {trigger_type_config}")
 

--- a/custom_components/flichub/strings.json
+++ b/custom_components/flichub/strings.json
@@ -56,7 +56,13 @@
       "hold_button_1": "Hold (Small button)",
       "down_button_1": "Button down (Small button)",
       "up_button_1": "Button up (Small button)",
-      "double_hold_button_1": "Double click and hold (Small button)"
+      "double_hold_button_1": "Double click and hold (Small button)",
+      "hold_release": "Hold release",
+      "double_hold_release": "Double click and hold release",
+      "hold_release_button_0": "Hold release (Large button)",
+      "double_hold_release_button_0": "Double click and hold release (Large button)",
+      "hold_release_button_1": "Hold release (Small button)",
+      "double_hold_release_button_1": "Double click and hold release (Small button)"
     }
   }
 }

--- a/custom_components/flichub/translations/en.json
+++ b/custom_components/flichub/translations/en.json
@@ -56,7 +56,13 @@
       "hold_button_1": "Hold (Small button)",
       "down_button_1": "Button down (Small button)",
       "up_button_1": "Button up (Small button)",
-      "double_hold_button_1": "Double click and hold (Small button)"
+      "double_hold_button_1": "Double click and hold (Small button)",
+      "hold_release": "Hold release",
+      "double_hold_release": "Double click and hold release",
+      "hold_release_button_0": "Hold release (Large button)",
+      "double_hold_release_button_0": "Double click and hold release (Large button)",
+      "hold_release_button_1": "Hold release (Small button)",
+      "double_hold_release_button_1": "Double click and hold release (Small button)"
     }
   }
 }


### PR DESCRIPTION
Previously in the Flic Hub tcp server code, the buttonDown and buttonUp events were simulated to fire consecutively when buttonSingleOrDoubleClickOrHold was fired, entirely obfuscating the time elapsed between the button physical press and release. 

Now the tcp server has been changed to instead bind directly to the native Flic Hub SDK buttonDown and buttonUp events so that pyflichub-tcpclient receivers are correctly notified exactly when physical interactions end. 

This PR adapts the integration to this behavior by synthesizing hold_release and double_hold_release events based on the last action triggered, thus enabling automations using device triggers for Flic buttons to distinguish when a hold begins and when it is released.

---
*PR created automatically by Jules for task [7850401120351178065](https://jules.google.com/task/7850401120351178065) started by @JohNan*